### PR TITLE
Move tar.xz to dist/artifacts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
 FROM golang
 COPY ./scripts/bootstrap /scripts/bootstrap
 RUN /scripts/bootstrap
+WORKDIR /source

--- a/scripts/package
+++ b/scripts/package
@@ -7,9 +7,9 @@ cd $(dirname $0)/..
 set_project_vars
 
 rm -rf dist
-mkdir -p dist
+mkdir -p dist/artifacts
 
 cd build
 echo "Packaging:"
-tar cvJf ../dist/$PROJECT.tar.xz .
-echo Created dist/$PROJECT.tar.xz
+tar cvJf ../dist/artifacts/$PROJECT.tar.xz .
+echo Created dist/artifacts/$PROJECT.tar.xz


### PR DESCRIPTION
This is just to better comform with the style of the other rancherio
builds.  Eventually we will automate creating releases and that will
assume any thing in the artifacts directory should be placed on some
release server.
