### PR TITLE
Fix docker connection parsing

### DIFF
--- a/handlers/bootstrap.go
+++ b/handlers/bootstrap.go
@@ -21,6 +21,8 @@ const (
 	parseMessage        = "Failed to parse config: [%v]"
 )
 
+var endpointRegEx = regexp.MustCompile("-H=[[:alnum:]]*[[:graph:]]*")
+
 func ActivateMachine(event *events.Event, apiClient *client.RancherClient) error {
 	log.WithFields(log.Fields{
 		"ResourceId": event.ResourceId,
@@ -261,7 +263,6 @@ func getConnectionConfig(machineDir string, machineName string) (*tlsConnectionC
 
 func parseConnectionArgs(args string) (*tlsConnectionConfig, error) {
 	// Extract the -H (host) parameter
-	endpointRegEx := regexp.MustCompile("-H=\".*\"")
 	endpointMatches := endpointRegEx.FindAllString(args, -1)
 	if len(endpointMatches) != 1 {
 		return nil, fmt.Errorf(parseMessage, args)

--- a/handlers/helpers_test.go
+++ b/handlers/helpers_test.go
@@ -13,11 +13,23 @@ func TestParseConnectionArgs(t *testing.T) {
 	key := "/foo/bar/key.pem"
 	endpoint := "tcp://127.0.0.1:2376"
 
+	// "Normal"
 	testArgs := fmt.Sprintf("--tls --tlscacert=%v   --tlscert=%v --tlskey=%v -H=\"%v\" ",
 		ca, cert, key, endpoint)
 	testParse(testArgs, ca, cert, key, endpoint, t)
 
+	// -H at beginning
 	testArgs = fmt.Sprintf("-H=\"%v\" --tlscacert=%v --tlscert=%v --tlskey=%v --tls",
+		endpoint, ca, cert, key)
+	testParse(testArgs, ca, cert, key, endpoint, t)
+
+	// -H at end with no quotes
+	testArgs = fmt.Sprintf("--tls --tlscacert=%v   --tlscert=%v --tlskey=%v -H=%v",
+		ca, cert, key, endpoint)
+	testParse(testArgs, ca, cert, key, endpoint, t)
+
+	// -H at beginning with no quotes
+	testArgs = fmt.Sprintf("-H=%v --tlscacert=%v --tlscert=%v --tlskey=%v --tls",
 		endpoint, ca, cert, key)
 	testParse(testArgs, ca, cert, key, endpoint, t)
 


### PR DESCRIPTION
docker-machine updated it's connection config output such that the -H parameter is no longer wrapped with quotes. This fixes that and remans backwards compatible with the version where the -H param is quoted.
