### PR TITLE
Add support for extracting machine config

### DIFF
--- a/events/listener.go
+++ b/events/listener.go
@@ -126,9 +126,6 @@ type Worker struct {
 func (w *Worker) DoWork(rawEvent []byte, eventHandlers map[string]EventHandler, apiClient *client.RancherClient,
 	workers chan *Worker) {
 	defer func() { workers <- w }()
-	log.WithFields(log.Fields{
-		"event": string(rawEvent[:]),
-	}).Debug("Processing event.")
 
 	event := &Event{}
 	err := json.Unmarshal(rawEvent, &event)
@@ -137,6 +134,12 @@ func (w *Worker) DoWork(rawEvent []byte, eventHandlers map[string]EventHandler, 
 			"err": err,
 		}).Error("Error unmarshalling event")
 		return
+	}
+
+	if event.Name != "ping" {
+		log.WithFields(log.Fields{
+			"event": string(rawEvent[:]),
+		}).Debug("Processing event.")
 	}
 
 	unlocker := locks.Lock(event.ResourceId)

--- a/handlers/digitalocean_test.go
+++ b/handlers/digitalocean_test.go
@@ -4,6 +4,7 @@ import (
 	"github.com/rancherio/go-machine-service/events"
 	"github.com/rancherio/go-rancher/client"
 	"os"
+	"path/filepath"
 	"strconv"
 	"testing"
 	"time"
@@ -68,7 +69,15 @@ func setupDO(access_token string) {
 
 	doMachineUpdate = func(current *client.Machine, machineUpdates *client.Machine,
 		apiClient *client.RancherClient) error {
-		machine.Data = machineUpdates.Data
+		if machineUpdates.Data != nil {
+			machine.Data = machineUpdates.Data
+		}
 		return nil
+	}
+
+	createExtractedConfig = func(event *events.Event, machine *client.Machine) (string, error) {
+		// return the config.json so it can be base64 encoded
+		configJson := filepath.Join(os.Getenv("CATTLE_HOME"), "machine", "ext-"+machine.Id, "machine", "machines", "name-"+machine.Id, "config.json")
+		return configJson, nil
 	}
 }

--- a/handlers/digitalocean_test.go
+++ b/handlers/digitalocean_test.go
@@ -4,7 +4,6 @@ import (
 	"github.com/rancherio/go-machine-service/events"
 	"github.com/rancherio/go-rancher/client"
 	"os"
-	"path/filepath"
 	"strconv"
 	"testing"
 	"time"
@@ -73,11 +72,5 @@ func setupDO(access_token string) {
 			machine.Data = machineUpdates.Data
 		}
 		return nil
-	}
-
-	createExtractedConfig = func(event *events.Event, machine *client.Machine) (string, error) {
-		// return the config.json so it can be base64 encoded
-		configJson := filepath.Join(os.Getenv("CATTLE_HOME"), "machine", "ext-"+machine.Id, "machine", "machines", "name-"+machine.Id, "config.json")
-		return configJson, nil
 	}
 }

--- a/handlers/virtualbox_test.go
+++ b/handlers/virtualbox_test.go
@@ -4,7 +4,6 @@ import (
 	"github.com/rancherio/go-machine-service/events"
 	"github.com/rancherio/go-rancher/client"
 	"os"
-	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
@@ -93,11 +92,5 @@ func setupVB() {
 			machine.Data = machineUpdates.Data
 		}
 		return nil
-	}
-
-	createExtractedConfig = func(event *events.Event, machine *client.Machine) (string, error) {
-		// return the config.json so it can be base64 encoded
-		configJson := filepath.Join(os.Getenv("CATTLE_HOME"), "machine", "ext-"+machine.Id, "machine", "machines", "name-"+machine.Id, "config.json")
-		return configJson, nil
 	}
 }

--- a/handlers/virtualbox_test.go
+++ b/handlers/virtualbox_test.go
@@ -4,6 +4,7 @@ import (
 	"github.com/rancherio/go-machine-service/events"
 	"github.com/rancherio/go-rancher/client"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
@@ -88,7 +89,15 @@ func setupVB() {
 
 	doMachineUpdate = func(current *client.Machine, machineUpdates *client.Machine,
 		apiClient *client.RancherClient) error {
-		machine.Data = machineUpdates.Data
+		if machineUpdates.Data != nil {
+			machine.Data = machineUpdates.Data
+		}
 		return nil
+	}
+
+	createExtractedConfig = func(event *events.Event, machine *client.Machine) (string, error) {
+		// return the config.json so it can be base64 encoded
+		configJson := filepath.Join(os.Getenv("CATTLE_HOME"), "machine", "ext-"+machine.Id, "machine", "machines", "name-"+machine.Id, "config.json")
+		return configJson, nil
 	}
 }


### PR DESCRIPTION
- machine will now tar.gz the entire machine config directory, base64 encode it, and store it in cattle. #8 
- removed ping logging. #15 

This requires the cattle PR: https://github.com/rancherio/cattle/pull/285
