### PR TITLE
Push data more reliably to cattle

### DIFF
--- a/handlers/bootstrap.go
+++ b/handlers/bootstrap.go
@@ -94,13 +94,11 @@ func ActivateMachine(event *events.Event, apiClient *client.RancherClient) error
 
 	t := time.Now()
 	bootstrappedAt := t.Format(time.RFC3339)
-	updates := map[string]string{bootstrappedAtField: bootstrappedAt}
-	err = updateMachineData(machine, updates, apiClient)
-	if err != nil {
-		return err
-	}
+	dataUpdates := map[string]interface{}{bootstrappedAtField: bootstrappedAt}
+	eventDataWrapper := map[string]interface{}{"+data": dataUpdates}
 
 	reply := newReply(event)
+	reply.Data = eventDataWrapper
 	return publishReply(reply, apiClient)
 }
 

--- a/handlers/common.go
+++ b/handlers/common.go
@@ -32,31 +32,6 @@ func getMachineDir(machine *client.Machine) (string, error) {
 	return machineDir, nil
 }
 
-func updateMachineData(machine *client.Machine, dataUpdates map[string]string,
-	apiClient *client.RancherClient) error {
-	latest, err := getMachine(machine.Id, apiClient)
-	if err != nil {
-		return err
-	}
-	data := latest.Data
-	if data == nil {
-		data = map[string]interface{}{}
-	}
-	for k, v := range dataUpdates {
-		data[k] = v
-	}
-	return doMachineUpdate(latest, &client.Machine{Data: data}, apiClient)
-}
-
-var doMachineUpdate = func(current *client.Machine, machineUpdates *client.Machine,
-	apiClient *client.RancherClient) error {
-	_, err := apiClient.Machine.Update(current, machineUpdates)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
 var publishReply = func(reply *client.Publish, apiClient *client.RancherClient) error {
 	_, err := apiClient.Publish.Create(reply)
 	return err

--- a/handlers/digitalocean_test.go
+++ b/handlers/digitalocean_test.go
@@ -64,15 +64,6 @@ func setupDO(access_token string) {
 		return "http://1.2.3.4/v1", nil
 	}
 
-	publishReply = func(reply *client.Publish, apiClient *client.RancherClient) error { return nil }
-
+	publishReply = buildMockPublishReply(machine)
 	publishTransitioningReply = func(msg string, event *events.Event, apiClient *client.RancherClient) {}
-
-	doMachineUpdate = func(current *client.Machine, machineUpdates *client.Machine,
-		apiClient *client.RancherClient) error {
-		if machineUpdates.Data != nil {
-			machine.Data = machineUpdates.Data
-		}
-		return nil
-	}
 }


### PR DESCRIPTION
go-machine-service must push some updates to the machine resources it
works on. This refactors how those updates are pushed. Before, updates
were pushed as individual PUTs on the machine reouse. Now, updates are
made all at once as part of the final event reply.
