### PR TITLE
Support for machine 0.2.0rc2 and other bug fixes

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -53,8 +53,8 @@
 		},
 		{
 			"ImportPath": "github.com/rancherio/go-rancher/client",
-			"Comment": "v0.1.0-5-ge133b53",
-			"Rev": "e133b53df51fc78250b865c44599ff5e43de23ea"
+			"Comment": "v0.1.0-7-g132e436",
+			"Rev": "132e436754b38044e8cb434b7977f3626d1ded95"
 		}
 	]
 }

--- a/Godeps/_workspace/src/github.com/rancherio/go-rancher/client/generated_add_remove_service_link_input.go
+++ b/Godeps/_workspace/src/github.com/rancherio/go-rancher/client/generated_add_remove_service_link_input.go
@@ -1,0 +1,63 @@
+package client
+
+const (
+	ADD_REMOVE_SERVICE_LINK_INPUT_TYPE = "addRemoveServiceLinkInput"
+)
+
+type AddRemoveServiceLinkInput struct {
+	Resource
+    
+    ServiceId string `json:"serviceId,omitempty"`
+    
+}
+
+type AddRemoveServiceLinkInputCollection struct {
+	Collection
+	Data []AddRemoveServiceLinkInput `json:"data,omitempty"`
+}
+
+type AddRemoveServiceLinkInputClient struct {
+	rancherClient *RancherClient
+}
+
+type AddRemoveServiceLinkInputOperations interface {
+	List(opts *ListOpts) (*AddRemoveServiceLinkInputCollection, error)
+	Create(opts *AddRemoveServiceLinkInput) (*AddRemoveServiceLinkInput, error)
+	Update(existing *AddRemoveServiceLinkInput, updates interface{}) (*AddRemoveServiceLinkInput, error)
+	ById(id string) (*AddRemoveServiceLinkInput, error)
+	Delete(container *AddRemoveServiceLinkInput) error
+}
+
+func newAddRemoveServiceLinkInputClient(rancherClient *RancherClient) *AddRemoveServiceLinkInputClient {
+	return &AddRemoveServiceLinkInputClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *AddRemoveServiceLinkInputClient) Create(container *AddRemoveServiceLinkInput) (*AddRemoveServiceLinkInput, error) {
+	resp := &AddRemoveServiceLinkInput{}
+	err := c.rancherClient.doCreate(ADD_REMOVE_SERVICE_LINK_INPUT_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *AddRemoveServiceLinkInputClient) Update(existing *AddRemoveServiceLinkInput, updates interface{}) (*AddRemoveServiceLinkInput, error) {
+	resp := &AddRemoveServiceLinkInput{}
+	err := c.rancherClient.doUpdate(ADD_REMOVE_SERVICE_LINK_INPUT_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *AddRemoveServiceLinkInputClient) List(opts *ListOpts) (*AddRemoveServiceLinkInputCollection, error) {
+	resp := &AddRemoveServiceLinkInputCollection{}
+	err := c.rancherClient.doList(ADD_REMOVE_SERVICE_LINK_INPUT_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *AddRemoveServiceLinkInputClient) ById(id string) (*AddRemoveServiceLinkInput, error) {
+	resp := &AddRemoveServiceLinkInput{}
+	err := c.rancherClient.doById(ADD_REMOVE_SERVICE_LINK_INPUT_TYPE, id, resp)
+	return resp, err
+}
+
+func (c *AddRemoveServiceLinkInputClient) Delete(container *AddRemoveServiceLinkInput) error {
+	return c.rancherClient.doResourceDelete(ADD_REMOVE_SERVICE_LINK_INPUT_TYPE, &container.Resource)
+}

--- a/Godeps/_workspace/src/github.com/rancherio/go-rancher/client/generated_client.go
+++ b/Godeps/_workspace/src/github.com/rancherio/go-rancher/client/generated_client.go
@@ -12,6 +12,7 @@ type RancherClient struct {
     GlobalLoadBalancerPolicy GlobalLoadBalancerPolicyOperations
     GlobalLoadBalancerHealthCheck GlobalLoadBalancerHealthCheckOperations
     ExternalHandlerProcessConfig ExternalHandlerProcessConfigOperations
+    ComposeConfig ComposeConfigOperations
     Container ContainerOperations
     ApiKey ApiKeyOperations
     InstanceStop InstanceStopOperations
@@ -25,12 +26,13 @@ type RancherClient struct {
     RemoveLoadBalancerInput RemoveLoadBalancerInputOperations
     AddRemoveLoadBalancerHostInput AddRemoveLoadBalancerHostInputOperations
     SetLoadBalancerListenersInput SetLoadBalancerListenersInputOperations
-    SetLoadBalancerTargetsInput SetLoadBalancerTargetsInputOperations
-    SetLoadBalancerHostsInput SetLoadBalancerHostsInputOperations
+    LoadBalancerUpdateAllInput LoadBalancerUpdateAllInputOperations
     Cluster ClusterOperations
     AddRemoveClusterHostInput AddRemoveClusterHostInputOperations
     RegistryCredential RegistryCredentialOperations
     Registry RegistryOperations
+    AddRemoveServiceLinkInput AddRemoveServiceLinkInputOperations
+    ComposeConfigInput ComposeConfigInputOperations
     Account AccountOperations
     Agent AgentOperations
     Certificate CertificateOperations
@@ -39,6 +41,7 @@ type RancherClient struct {
     Credential CredentialOperations
     Databasechangelog DatabasechangelogOperations
     Databasechangeloglock DatabasechangeloglockOperations
+    Environment EnvironmentOperations
     ExternalHandler ExternalHandlerOperations
     ExternalHandlerExternalHandlerProcessMap ExternalHandlerExternalHandlerProcessMapOperations
     ExternalHandlerProcess ExternalHandlerProcessOperations
@@ -58,6 +61,7 @@ type RancherClient struct {
     Port PortOperations
     ProcessExecution ProcessExecutionOperations
     ProcessInstance ProcessInstanceOperations
+    Service ServiceOperations
     Setting SettingOperations
     StoragePool StoragePoolOperations
     Task TaskOperations
@@ -99,6 +103,7 @@ func constructClient() *RancherClient {
     client.GlobalLoadBalancerPolicy = newGlobalLoadBalancerPolicyClient(client)
     client.GlobalLoadBalancerHealthCheck = newGlobalLoadBalancerHealthCheckClient(client)
     client.ExternalHandlerProcessConfig = newExternalHandlerProcessConfigClient(client)
+    client.ComposeConfig = newComposeConfigClient(client)
     client.Container = newContainerClient(client)
     client.ApiKey = newApiKeyClient(client)
     client.InstanceStop = newInstanceStopClient(client)
@@ -112,12 +117,13 @@ func constructClient() *RancherClient {
     client.RemoveLoadBalancerInput = newRemoveLoadBalancerInputClient(client)
     client.AddRemoveLoadBalancerHostInput = newAddRemoveLoadBalancerHostInputClient(client)
     client.SetLoadBalancerListenersInput = newSetLoadBalancerListenersInputClient(client)
-    client.SetLoadBalancerTargetsInput = newSetLoadBalancerTargetsInputClient(client)
-    client.SetLoadBalancerHostsInput = newSetLoadBalancerHostsInputClient(client)
+    client.LoadBalancerUpdateAllInput = newLoadBalancerUpdateAllInputClient(client)
     client.Cluster = newClusterClient(client)
     client.AddRemoveClusterHostInput = newAddRemoveClusterHostInputClient(client)
     client.RegistryCredential = newRegistryCredentialClient(client)
     client.Registry = newRegistryClient(client)
+    client.AddRemoveServiceLinkInput = newAddRemoveServiceLinkInputClient(client)
+    client.ComposeConfigInput = newComposeConfigInputClient(client)
     client.Account = newAccountClient(client)
     client.Agent = newAgentClient(client)
     client.Certificate = newCertificateClient(client)
@@ -126,6 +132,7 @@ func constructClient() *RancherClient {
     client.Credential = newCredentialClient(client)
     client.Databasechangelog = newDatabasechangelogClient(client)
     client.Databasechangeloglock = newDatabasechangeloglockClient(client)
+    client.Environment = newEnvironmentClient(client)
     client.ExternalHandler = newExternalHandlerClient(client)
     client.ExternalHandlerExternalHandlerProcessMap = newExternalHandlerExternalHandlerProcessMapClient(client)
     client.ExternalHandlerProcess = newExternalHandlerProcessClient(client)
@@ -145,6 +152,7 @@ func constructClient() *RancherClient {
     client.Port = newPortClient(client)
     client.ProcessExecution = newProcessExecutionClient(client)
     client.ProcessInstance = newProcessInstanceClient(client)
+    client.Service = newServiceClient(client)
     client.Setting = newSettingClient(client)
     client.StoragePool = newStoragePoolClient(client)
     client.Task = newTaskClient(client)

--- a/Godeps/_workspace/src/github.com/rancherio/go-rancher/client/generated_cluster.go
+++ b/Godeps/_workspace/src/github.com/rancherio/go-rancher/client/generated_cluster.go
@@ -13,8 +13,6 @@ type Cluster struct {
     
     ApiProxy string `json:"apiProxy,omitempty"`
     
-    CertificateId string `json:"certificateId,omitempty"`
-    
     ComputeTotal int `json:"computeTotal,omitempty"`
     
     Created string `json:"created,omitempty"`

--- a/Godeps/_workspace/src/github.com/rancherio/go-rancher/client/generated_compose_config.go
+++ b/Godeps/_workspace/src/github.com/rancherio/go-rancher/client/generated_compose_config.go
@@ -1,0 +1,65 @@
+package client
+
+const (
+	COMPOSE_CONFIG_TYPE = "composeConfig"
+)
+
+type ComposeConfig struct {
+	Resource
+    
+    DockerComposeConfig string `json:"dockerComposeConfig,omitempty"`
+    
+    RancherComposeConfig string `json:"rancherComposeConfig,omitempty"`
+    
+}
+
+type ComposeConfigCollection struct {
+	Collection
+	Data []ComposeConfig `json:"data,omitempty"`
+}
+
+type ComposeConfigClient struct {
+	rancherClient *RancherClient
+}
+
+type ComposeConfigOperations interface {
+	List(opts *ListOpts) (*ComposeConfigCollection, error)
+	Create(opts *ComposeConfig) (*ComposeConfig, error)
+	Update(existing *ComposeConfig, updates interface{}) (*ComposeConfig, error)
+	ById(id string) (*ComposeConfig, error)
+	Delete(container *ComposeConfig) error
+}
+
+func newComposeConfigClient(rancherClient *RancherClient) *ComposeConfigClient {
+	return &ComposeConfigClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *ComposeConfigClient) Create(container *ComposeConfig) (*ComposeConfig, error) {
+	resp := &ComposeConfig{}
+	err := c.rancherClient.doCreate(COMPOSE_CONFIG_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *ComposeConfigClient) Update(existing *ComposeConfig, updates interface{}) (*ComposeConfig, error) {
+	resp := &ComposeConfig{}
+	err := c.rancherClient.doUpdate(COMPOSE_CONFIG_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *ComposeConfigClient) List(opts *ListOpts) (*ComposeConfigCollection, error) {
+	resp := &ComposeConfigCollection{}
+	err := c.rancherClient.doList(COMPOSE_CONFIG_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *ComposeConfigClient) ById(id string) (*ComposeConfig, error) {
+	resp := &ComposeConfig{}
+	err := c.rancherClient.doById(COMPOSE_CONFIG_TYPE, id, resp)
+	return resp, err
+}
+
+func (c *ComposeConfigClient) Delete(container *ComposeConfig) error {
+	return c.rancherClient.doResourceDelete(COMPOSE_CONFIG_TYPE, &container.Resource)
+}

--- a/Godeps/_workspace/src/github.com/rancherio/go-rancher/client/generated_compose_config_input.go
+++ b/Godeps/_workspace/src/github.com/rancherio/go-rancher/client/generated_compose_config_input.go
@@ -1,0 +1,63 @@
+package client
+
+const (
+	COMPOSE_CONFIG_INPUT_TYPE = "composeConfigInput"
+)
+
+type ComposeConfigInput struct {
+	Resource
+    
+    ServiceIds []string `json:"serviceIds,omitempty"`
+    
+}
+
+type ComposeConfigInputCollection struct {
+	Collection
+	Data []ComposeConfigInput `json:"data,omitempty"`
+}
+
+type ComposeConfigInputClient struct {
+	rancherClient *RancherClient
+}
+
+type ComposeConfigInputOperations interface {
+	List(opts *ListOpts) (*ComposeConfigInputCollection, error)
+	Create(opts *ComposeConfigInput) (*ComposeConfigInput, error)
+	Update(existing *ComposeConfigInput, updates interface{}) (*ComposeConfigInput, error)
+	ById(id string) (*ComposeConfigInput, error)
+	Delete(container *ComposeConfigInput) error
+}
+
+func newComposeConfigInputClient(rancherClient *RancherClient) *ComposeConfigInputClient {
+	return &ComposeConfigInputClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *ComposeConfigInputClient) Create(container *ComposeConfigInput) (*ComposeConfigInput, error) {
+	resp := &ComposeConfigInput{}
+	err := c.rancherClient.doCreate(COMPOSE_CONFIG_INPUT_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *ComposeConfigInputClient) Update(existing *ComposeConfigInput, updates interface{}) (*ComposeConfigInput, error) {
+	resp := &ComposeConfigInput{}
+	err := c.rancherClient.doUpdate(COMPOSE_CONFIG_INPUT_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *ComposeConfigInputClient) List(opts *ListOpts) (*ComposeConfigInputCollection, error) {
+	resp := &ComposeConfigInputCollection{}
+	err := c.rancherClient.doList(COMPOSE_CONFIG_INPUT_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *ComposeConfigInputClient) ById(id string) (*ComposeConfigInput, error) {
+	resp := &ComposeConfigInput{}
+	err := c.rancherClient.doById(COMPOSE_CONFIG_INPUT_TYPE, id, resp)
+	return resp, err
+}
+
+func (c *ComposeConfigInputClient) Delete(container *ComposeConfigInput) error {
+	return c.rancherClient.doResourceDelete(COMPOSE_CONFIG_INPUT_TYPE, &container.Resource)
+}

--- a/Godeps/_workspace/src/github.com/rancherio/go-rancher/client/generated_digitalocean_config.go
+++ b/Godeps/_workspace/src/github.com/rancherio/go-rancher/client/generated_digitalocean_config.go
@@ -9,7 +9,13 @@ type DigitaloceanConfig struct {
     
     AccessToken string `json:"accessToken,omitempty"`
     
+    Backups bool `json:"backups,omitempty"`
+    
     Image string `json:"image,omitempty"`
+    
+    Ipv6 bool `json:"ipv6,omitempty"`
+    
+    PrivateNetworking bool `json:"privateNetworking,omitempty"`
     
     Region string `json:"region,omitempty"`
     

--- a/Godeps/_workspace/src/github.com/rancherio/go-rancher/client/generated_environment.go
+++ b/Godeps/_workspace/src/github.com/rancherio/go-rancher/client/generated_environment.go
@@ -1,0 +1,101 @@
+package client
+
+const (
+	ENVIRONMENT_TYPE = "environment"
+)
+
+type Environment struct {
+	Resource
+    
+    AccountId string `json:"accountId,omitempty"`
+    
+    Created string `json:"created,omitempty"`
+    
+    Data map[string]interface{} `json:"data,omitempty"`
+    
+    Description string `json:"description,omitempty"`
+    
+    Kind string `json:"kind,omitempty"`
+    
+    Name string `json:"name,omitempty"`
+    
+    RemoveTime string `json:"removeTime,omitempty"`
+    
+    Removed string `json:"removed,omitempty"`
+    
+    State string `json:"state,omitempty"`
+    
+    Transitioning string `json:"transitioning,omitempty"`
+    
+    TransitioningMessage string `json:"transitioningMessage,omitempty"`
+    
+    TransitioningProgress int `json:"transitioningProgress,omitempty"`
+    
+    Uuid string `json:"uuid,omitempty"`
+    
+}
+
+type EnvironmentCollection struct {
+	Collection
+	Data []Environment `json:"data,omitempty"`
+}
+
+type EnvironmentClient struct {
+	rancherClient *RancherClient
+}
+
+type EnvironmentOperations interface {
+	List(opts *ListOpts) (*EnvironmentCollection, error)
+	Create(opts *Environment) (*Environment, error)
+	Update(existing *Environment, updates interface{}) (*Environment, error)
+	ById(id string) (*Environment, error)
+	Delete(container *Environment) error
+    ActionCreate (*Environment) (*Environment, error)
+    ActionRemove (*Environment) (*Environment, error)
+}
+
+func newEnvironmentClient(rancherClient *RancherClient) *EnvironmentClient {
+	return &EnvironmentClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *EnvironmentClient) Create(container *Environment) (*Environment, error) {
+	resp := &Environment{}
+	err := c.rancherClient.doCreate(ENVIRONMENT_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *EnvironmentClient) Update(existing *Environment, updates interface{}) (*Environment, error) {
+	resp := &Environment{}
+	err := c.rancherClient.doUpdate(ENVIRONMENT_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *EnvironmentClient) List(opts *ListOpts) (*EnvironmentCollection, error) {
+	resp := &EnvironmentCollection{}
+	err := c.rancherClient.doList(ENVIRONMENT_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *EnvironmentClient) ById(id string) (*Environment, error) {
+	resp := &Environment{}
+	err := c.rancherClient.doById(ENVIRONMENT_TYPE, id, resp)
+	return resp, err
+}
+
+func (c *EnvironmentClient) Delete(container *Environment) error {
+	return c.rancherClient.doResourceDelete(ENVIRONMENT_TYPE, &container.Resource)
+}
+
+func (c *EnvironmentClient) ActionCreate(resource *Environment) (*Environment, error) {
+	resp := &Environment{}
+	err := c.rancherClient.doEmptyAction(ENVIRONMENT_TYPE, "create", &resource.Resource, resp)
+	return resp, err
+}
+
+func (c *EnvironmentClient) ActionRemove(resource *Environment) (*Environment, error) {
+	resp := &Environment{}
+	err := c.rancherClient.doEmptyAction(ENVIRONMENT_TYPE, "remove", &resource.Resource, resp)
+	return resp, err
+}

--- a/Godeps/_workspace/src/github.com/rancherio/go-rancher/client/generated_load_balancer_update_all_input.go
+++ b/Godeps/_workspace/src/github.com/rancherio/go-rancher/client/generated_load_balancer_update_all_input.go
@@ -1,0 +1,67 @@
+package client
+
+const (
+	LOAD_BALANCER_UPDATE_ALL_INPUT_TYPE = "loadBalancerUpdateAllInput"
+)
+
+type LoadBalancerUpdateAllInput struct {
+	Resource
+    
+    HostIds []string `json:"hostIds,omitempty"`
+    
+    InstanceIds []string `json:"instanceIds,omitempty"`
+    
+    IpAddresses []string `json:"ipAddresses,omitempty"`
+    
+}
+
+type LoadBalancerUpdateAllInputCollection struct {
+	Collection
+	Data []LoadBalancerUpdateAllInput `json:"data,omitempty"`
+}
+
+type LoadBalancerUpdateAllInputClient struct {
+	rancherClient *RancherClient
+}
+
+type LoadBalancerUpdateAllInputOperations interface {
+	List(opts *ListOpts) (*LoadBalancerUpdateAllInputCollection, error)
+	Create(opts *LoadBalancerUpdateAllInput) (*LoadBalancerUpdateAllInput, error)
+	Update(existing *LoadBalancerUpdateAllInput, updates interface{}) (*LoadBalancerUpdateAllInput, error)
+	ById(id string) (*LoadBalancerUpdateAllInput, error)
+	Delete(container *LoadBalancerUpdateAllInput) error
+}
+
+func newLoadBalancerUpdateAllInputClient(rancherClient *RancherClient) *LoadBalancerUpdateAllInputClient {
+	return &LoadBalancerUpdateAllInputClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *LoadBalancerUpdateAllInputClient) Create(container *LoadBalancerUpdateAllInput) (*LoadBalancerUpdateAllInput, error) {
+	resp := &LoadBalancerUpdateAllInput{}
+	err := c.rancherClient.doCreate(LOAD_BALANCER_UPDATE_ALL_INPUT_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *LoadBalancerUpdateAllInputClient) Update(existing *LoadBalancerUpdateAllInput, updates interface{}) (*LoadBalancerUpdateAllInput, error) {
+	resp := &LoadBalancerUpdateAllInput{}
+	err := c.rancherClient.doUpdate(LOAD_BALANCER_UPDATE_ALL_INPUT_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *LoadBalancerUpdateAllInputClient) List(opts *ListOpts) (*LoadBalancerUpdateAllInputCollection, error) {
+	resp := &LoadBalancerUpdateAllInputCollection{}
+	err := c.rancherClient.doList(LOAD_BALANCER_UPDATE_ALL_INPUT_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *LoadBalancerUpdateAllInputClient) ById(id string) (*LoadBalancerUpdateAllInput, error) {
+	resp := &LoadBalancerUpdateAllInput{}
+	err := c.rancherClient.doById(LOAD_BALANCER_UPDATE_ALL_INPUT_TYPE, id, resp)
+	return resp, err
+}
+
+func (c *LoadBalancerUpdateAllInputClient) Delete(container *LoadBalancerUpdateAllInput) error {
+	return c.rancherClient.doResourceDelete(LOAD_BALANCER_UPDATE_ALL_INPUT_TYPE, &container.Resource)
+}

--- a/Godeps/_workspace/src/github.com/rancherio/go-rancher/client/generated_service.go
+++ b/Godeps/_workspace/src/github.com/rancherio/go-rancher/client/generated_service.go
@@ -1,0 +1,123 @@
+package client
+
+const (
+	SERVICE_TYPE = "service"
+)
+
+type Service struct {
+	Resource
+    
+    AccountId string `json:"accountId,omitempty"`
+    
+    Created string `json:"created,omitempty"`
+    
+    Data map[string]interface{} `json:"data,omitempty"`
+    
+    DataVolumesFromService []string `json:"dataVolumesFromService,omitempty"`
+    
+    Description string `json:"description,omitempty"`
+    
+    EnvironmentId string `json:"environmentId,omitempty"`
+    
+    Kind string `json:"kind,omitempty"`
+    
+    LaunchConfig Container `json:"launchConfig,omitempty"`
+    
+    Name string `json:"name,omitempty"`
+    
+    RemoveTime string `json:"removeTime,omitempty"`
+    
+    Removed string `json:"removed,omitempty"`
+    
+    Scale int `json:"scale,omitempty"`
+    
+    State string `json:"state,omitempty"`
+    
+    Transitioning string `json:"transitioning,omitempty"`
+    
+    TransitioningMessage string `json:"transitioningMessage,omitempty"`
+    
+    TransitioningProgress int `json:"transitioningProgress,omitempty"`
+    
+    Uuid string `json:"uuid,omitempty"`
+    
+}
+
+type ServiceCollection struct {
+	Collection
+	Data []Service `json:"data,omitempty"`
+}
+
+type ServiceClient struct {
+	rancherClient *RancherClient
+}
+
+type ServiceOperations interface {
+	List(opts *ListOpts) (*ServiceCollection, error)
+	Create(opts *Service) (*Service, error)
+	Update(existing *Service, updates interface{}) (*Service, error)
+	ById(id string) (*Service, error)
+	Delete(container *Service) error
+    ActionActivate (*Service) (*Service, error)
+    ActionCreate (*Service) (*Service, error)
+    ActionDeactivate (*Service) (*Service, error)
+    ActionRemove (*Service) (*Service, error)
+}
+
+func newServiceClient(rancherClient *RancherClient) *ServiceClient {
+	return &ServiceClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *ServiceClient) Create(container *Service) (*Service, error) {
+	resp := &Service{}
+	err := c.rancherClient.doCreate(SERVICE_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *ServiceClient) Update(existing *Service, updates interface{}) (*Service, error) {
+	resp := &Service{}
+	err := c.rancherClient.doUpdate(SERVICE_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *ServiceClient) List(opts *ListOpts) (*ServiceCollection, error) {
+	resp := &ServiceCollection{}
+	err := c.rancherClient.doList(SERVICE_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *ServiceClient) ById(id string) (*Service, error) {
+	resp := &Service{}
+	err := c.rancherClient.doById(SERVICE_TYPE, id, resp)
+	return resp, err
+}
+
+func (c *ServiceClient) Delete(container *Service) error {
+	return c.rancherClient.doResourceDelete(SERVICE_TYPE, &container.Resource)
+}
+
+func (c *ServiceClient) ActionActivate(resource *Service) (*Service, error) {
+	resp := &Service{}
+	err := c.rancherClient.doEmptyAction(SERVICE_TYPE, "activate", &resource.Resource, resp)
+	return resp, err
+}
+
+func (c *ServiceClient) ActionCreate(resource *Service) (*Service, error) {
+	resp := &Service{}
+	err := c.rancherClient.doEmptyAction(SERVICE_TYPE, "create", &resource.Resource, resp)
+	return resp, err
+}
+
+func (c *ServiceClient) ActionDeactivate(resource *Service) (*Service, error) {
+	resp := &Service{}
+	err := c.rancherClient.doEmptyAction(SERVICE_TYPE, "deactivate", &resource.Resource, resp)
+	return resp, err
+}
+
+func (c *ServiceClient) ActionRemove(resource *Service) (*Service, error) {
+	resp := &Service{}
+	err := c.rancherClient.doEmptyAction(SERVICE_TYPE, "remove", &resource.Resource, resp)
+	return resp, err
+}

--- a/handlers/bootstrap.go
+++ b/handlers/bootstrap.go
@@ -291,7 +291,7 @@ func parseConnectionArgs(args string) (*tlsConnectionConfig, error) {
 		kv := strings.Split(arg, "=")
 		if len(kv) == 2 {
 			key := strings.TrimSpace(kv[0])
-			val := strings.TrimSpace(kv[1])
+			val := strings.Trim(kv[1], "\" ")
 			switch key {
 			case "tlscacert":
 				config.caCert = val


### PR DESCRIPTION
- Added support for machine 0.2.0rc2
  - 0.2.0 changed the directory from [storage_path]/[uuid]/machine/machines (0.1.0) to [storage_path]/[uuid]/**machines**
  - docker-machine config also now returns tlscacert=**"**[string]**"** rather than tslcacert=[string] with a double-quote.
- Blacklisted a few more docker machine stdout messages so the messages look better
- Fixed several issues related with parsing error msgs from docker and returning it.
  - rancherio/rancher#371
  - rancherio/rancher#372
  - rancherio/rancher#373
  - rancherio/rancher#379 - added code to at least protect go-machine from missing machine names
