### PR TITLE
Use reflection to generically handle machine drivers sent by cattle

### DIFF
--- a/handlers/amazonec2_test.go
+++ b/handlers/amazonec2_test.go
@@ -13,13 +13,13 @@ func TestAmazonec2(t *testing.T) {
 	accessKey := os.Getenv("EC2_ACCESS_KEY")
 	secretKey := os.Getenv("EC2_SECRET_KEY")
 	vpcId := os.Getenv("EC2_VPC_ID")
-	subnetId := os.Getenv("EC2_SUBNET_ID")
+	zone := os.Getenv("EC2_ZONE")
 
-	if accessKey == "" || secretKey == "" || vpcId == "" || subnetId == "" {
+	if accessKey == "" || secretKey == "" || vpcId == "" {
 		t.Log("Skipping Amazon EC2 Test.")
 		return
 	}
-	setup(accessKey, secretKey, vpcId, subnetId)
+	setup(accessKey, secretKey, vpcId, zone)
 
 	resourceId := "EC2-" + strconv.FormatInt(time.Now().Unix(), 10)
 	event := &events.Event{
@@ -47,14 +47,14 @@ func TestAmazonec2(t *testing.T) {
 	}
 }
 
-func setup(accessKey string, secretKey string, vpcId string, subnetId string) {
+func setup(accessKey string, secretKey string, vpcId string, zone string) {
 	// TODO Replace functions during teardown.
 	machine := &client.Machine{
 		Amazonec2Config: client.Amazonec2Config{
 			AccessKey: accessKey,
 			SecretKey: secretKey,
 			VpcId:     vpcId,
-			SubnetId:  subnetId,
+			Zone:      zone,
 		},
 		Kind:   "machine",
 		Driver: "Amazonec2",

--- a/handlers/digitalocean_test.go
+++ b/handlers/digitalocean_test.go
@@ -52,7 +52,7 @@ func setupDO(access_token string) {
 			Size:              "1gb",
 			Image:             "ubuntu-14-04-x64",
 			Ipv6:              true,
-			Backups:           true,
+			Backups:           false,
 			PrivateNetworking: true,
 		},
 		Kind:   "machine",

--- a/handlers/helpers_test.go
+++ b/handlers/helpers_test.go
@@ -84,6 +84,78 @@ func TestParseConnectionArgs(t *testing.T) {
 
 }
 
+// Test the generic build create command function
+func TestBuildMachineCreateCmd(t *testing.T) {
+
+	// Tests: false boolean param, true boolean param, missing boolean param, and string params
+	testCmd := []string{
+		"create",
+		"-d",
+		"digitalocean",
+		"--digitalocean-access-token",
+		"abc",
+		"--digitalocean-image",
+		"ubuntu-14-04-x64",
+		"--digitalocean-ipv6",
+		"--digitalocean-region",
+		"sfo1",
+		"--digitalocean-size",
+		"1gb",
+		"testDO"}
+	machine := &client.Machine{
+		DigitaloceanConfig: client.DigitaloceanConfig{
+			AccessToken: "abc",
+			Region:      "sfo1",
+			Size:        "1gb",
+			Image:       "ubuntu-14-04-x64",
+			Ipv6:        true,
+			Backups:     false,
+		},
+		Kind:   "machine",
+		Driver: "DigitalOcean",
+		Name:   "testDO",
+	}
+	checkCommands(testCmd, machine, t)
+
+	// Test for no params
+	testCmd = []string{
+		"create",
+		"-d",
+		"virtualbox",
+		"testVB"}
+	machine = &client.Machine{
+		VirtualboxConfig: client.VirtualboxConfig{},
+		Kind:             "machine",
+		Driver:           "VirtualBox",
+		Name:             "testVB",
+	}
+	checkCommands(testCmd, machine, t)
+}
+
+func strsEquals(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i, v := range a {
+		if v != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func checkCommands(testCmd []string, machine *client.Machine, t *testing.T) {
+	cmd, err := buildMachineCreateCmd(machine)
+	if err != nil {
+		t.Fatalf("Error building command", err)
+	}
+
+	if !strsEquals(cmd, testCmd) {
+		t.Logf("Mismatch commands.  Expected: [%v], Actual: [%v]", testCmd, cmd)
+		t.FailNow()
+	}
+}
+
 func testParse(testArgs, ca, cert, key, endpoint string, t *testing.T) {
 	config, err := parseConnectionArgs(testArgs)
 	if err != nil {


### PR DESCRIPTION
First step in supporting generic machine drivers.  It will now parse client.Machine and change it to appropriate machine CLI params.

@cjellick for review
