### PR TITLE
add version info and gitcommit info on build/startup

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,16 +2,24 @@ package main
 
 import (
 	"flag"
+	"fmt"
+	"os"
+
 	log "github.com/Sirupsen/logrus"
 	"github.com/rancherio/go-machine-service/events"
 	"github.com/rancherio/go-machine-service/handlers"
-	"os"
+)
+
+var (
+	GITCOMMIT = "HEAD"
 )
 
 func main() {
 	processCmdLineFlags()
 
-	log.Info("Starting go-machine-service...")
+	log.WithFields(log.Fields{
+		"gitcommit": GITCOMMIT,
+	}).Info("Starting go-machine-service...")
 	eventHandlers := map[string]events.EventHandler{
 		"physicalhost.create":    handlers.CreateMachine,
 		"physicalhost.bootstrap": handlers.ActivateMachine,
@@ -43,8 +51,14 @@ func main() {
 func processCmdLineFlags() {
 	// Define command line flags
 	logLevel := flag.String("loglevel", "info", "Set the default loglevel (default:info) [debug|info|warn|error]")
+	version := flag.Bool("v", false, "read the version of the go-machine-service")
 
 	flag.Parse()
+
+	if *version {
+		fmt.Printf("go-machine-service\t gitcommit=%s\n", GITCOMMIT)
+		os.Exit(0)
+	}
 
 	// Process log level.  If an invalid level is passed in, we simply default to info.
 	if parsedLogLevel, err := log.ParseLevel(*logLevel); err == nil {

--- a/scripts/build
+++ b/scripts/build
@@ -8,6 +8,8 @@ cd $(dirname $0)/..
 . ./scripts/common_functions
 set_project_vars
 
+GITCOMMIT=`git rev-parse --short HEAD`
+
 if [ -L ${PACKAGE} ]; then
     rm ${PACKAGE}
 fi
@@ -19,4 +21,4 @@ fi
 
 rm -rf build
 mkdir -p build
-go build -o build/${PROJECT}
+go build -o build/${PROJECT} -ldflags "-X main.GITCOMMIT $GITCOMMIT"


### PR DESCRIPTION
@will-chan @cjellick 

@cjellick - There is no way to figure out the version and exact git commit of the go-machine-service that is running. While debugging the issue yesterday, we couldn't figure out the version easily. This PR is meant to address that problem. 

Also, this PR introduces an extra step to the build and release process. The person releasing henceforth, has to update main.VERSION variable and then make the release.
