### PR TITLE
Better error messaging for v0.3.0 of docker-machine

### DIFF
--- a/handlers/create.go
+++ b/handlers/create.go
@@ -152,39 +152,30 @@ func logProgress(readerStdout io.Reader, readerStderr io.Reader, publishChan cha
 		log.WithFields(log.Fields{
 			"resourceId: ": event.ResourceId,
 		}).Infof("stdout: %s", msg)
-		msg = filterDockerMessage(msg, machine, errChan)
-		if msg != "" {
-			publishChan <- msg
+		transitionMsg := filterDockerMessage(msg, machine, errChan)
+		if transitionMsg != "" {
+			publishChan <- transitionMsg
 		}
 	}
 	scanner = bufio.NewScanner(readerStderr)
 	for scanner.Scan() {
+		msg := scanner.Text()
 		log.WithFields(log.Fields{
 			"resourceId": event.ResourceId,
-		}).Infof("stderr: %s", scanner.Text())
+		}).Infof("stderr: %s", msg)
+		filterDockerMessage(msg, machine, errChan)
 	}
 }
 
 func filterDockerMessage(msg string, machine *client.Machine, errChan chan<- string) string {
-	// Docker log messages come in the format: time=<t> level=<log-level> msg=<message>
-	// The minimum string should be greater than 7 characters msg="."
-	match := regExDockerMsg.FindString(msg)
-	if len(match) < 7 || !strings.HasPrefix(match, "msg=\"") {
+	if strings.Contains(msg, errorCreatingMachine) {
+		errChan <- strings.Replace(msg, errorCreatingMachine, "", 1)
 		return ""
 	}
-
-	match = (match[5 : len(strings.TrimSpace(match))-1])
-	if strings.Contains(msg, levelInfo) {
-		// We just want to return <message> to cattle and only messages that do not contain the machine uuid or namee
-		if strings.Contains(msg, machine.ExternalId) || strings.Contains(msg, machine.Name) {
-			return ""
-		}
-		return match
-	} else if strings.Contains(msg, levelError) {
-		errChan <- strings.Replace(match, errorCreatingMachine, "", 1)
+	if strings.Contains(msg, machine.ExternalId) || strings.Contains(msg, machine.Name) {
 		return ""
 	}
-	return ""
+	return msg
 }
 
 func startReturnOutput(command *exec.Cmd) (io.Reader, io.Reader, error) {

--- a/handlers/helpers_test.go
+++ b/handlers/helpers_test.go
@@ -14,38 +14,19 @@ func TestFilterDockerMessages(t *testing.T) {
 		ExternalId: "uuid-1",
 		Name:       "machine-1",
 	}
-	prefix := "time=\"2015-04-01T13:47:25-07:00\" level=\"info\" "
 
-	testString := prefix + "msg=\"Message\" "
-	checkField("Test1", "Message", filterDockerMessage(testString, machine, errChan), t)
+	testString := "Error creating machine: Message"
+	filterDockerMessage(testString, machine, errChan)
+	checkField("Test1", "Message", <-errChan, t)
 
-	testString = prefix + "msg=\"Message with externalId=uuid-1\" "
+	testString = "Message with externalId=uuid-1"
 	checkField("Test2", "", filterDockerMessage(testString, machine, errChan), t)
 
-	testString = prefix + "msg=\"Message with name=machine-1\" "
+	testString = "Message with name=machine-1"
 	checkField("Test3", "", filterDockerMessage(testString, machine, errChan), t)
 
-	testString = prefix + "msg=\"Message with random characters: =\"=\"\" "
+	testString = "Message with random characters: =\"=\""
 	checkField("Test4", "Message with random characters: =\"=\"", filterDockerMessage(testString, machine, errChan), t)
-
-	testString = prefix + "msg="
-	checkField("Test5", "", filterDockerMessage(testString, machine, errChan), t)
-
-	testString = prefix + "Really weird message"
-	checkField("Test6", "", filterDockerMessage(testString, machine, errChan), t)
-
-	// warning level check
-	testString = "time=\"2015-04-01T13:47:25-07:00\" level=\"warning\" msg=\"error message\" "
-	checkField("Test7", "", filterDockerMessage(testString, machine, errChan), t)
-
-	// fatal level check
-	testString = "time=\"2015-04-01T13:47:25-07:00\" level=\"fatal\" msg=\"error message\" "
-	checkField("Test8", "", filterDockerMessage(testString, machine, errChan), t)
-
-	//error level check
-	testString = "time=\"2015-04-01T13:47:25-07:00\" level=\"error\" msg=\"Error creating machine: error message\" "
-	checkField("Test9", "", filterDockerMessage(testString, machine, errChan), t)
-	checkField("Test9:errString", "error message", <-errChan, t)
 }
 
 // Tests the simplest case of successfully receiving, routing, and handling


### PR DESCRIPTION
@cjellick @will-chan 

the changes in this PR ensure that we get the correct error message from docker-machine when things go wrong. With v0.3.0, we've been only getting "exit status 1" so far. This change is supposed to fix that.
