### PR TITLE
Make test insensitive to param order

### DIFF
--- a/handlers/bootstrap_test.go
+++ b/handlers/bootstrap_test.go
@@ -19,7 +19,7 @@ func TestBuildContainerConfig(t *testing.T) {
 	config := buildContainerConfig([]string{}, machine, "rancher/agent", "0.7.8")
 
 	for _, elem := range config.Env {
-		if elem == "CATTLE_HOST_LABELS=abc=def&foo=bar" {
+		if elem == "CATTLE_HOST_LABELS=abc=def&foo=bar" || elem == "CATTLE_HOST_LABELS=foo=bar&abc=def" {
 			return
 		}
 	}


### PR DESCRIPTION
TestBuildContainerConfig checks for the existence of a certain label,
but it was sensitive to the order of the parameters in the value of the
label. This makes it insensitive to the order
