### PR TITLE
Handle rancher client returning nil on 404s

### DIFF
--- a/handlers/common.go
+++ b/handlers/common.go
@@ -103,12 +103,9 @@ var getMachine = func(id string, apiClient *client.RancherClient) (*client.Machi
 	return apiClient.Machine.ById(id)
 }
 
-func handleByIdError(err error, event *events.Event, apiClient *client.RancherClient) error {
-	apiError, ok := err.(*client.ApiError)
-	if !ok || apiError.StatusCode != 404 {
-		return err
-	}
-	// 404 Indicates this is a physicalHost but not a machine. Just reply.
+func notAMachineReply(event *events.Event, apiClient *client.RancherClient) error {
+	// Called when machine.ById() returned a 404, which indicates this is a
+	// physicalHost but not a machine. Just reply.
 	reply := newReply(event)
 	return publishReply(reply, apiClient)
 }

--- a/handlers/remove.go
+++ b/handlers/remove.go
@@ -16,7 +16,10 @@ func PurgeMachine(event *events.Event, apiClient *client.RancherClient) error {
 
 	machine, err := getMachine(event.ResourceId, apiClient)
 	if err != nil {
-		return handleByIdError(err, event, apiClient)
+		return err
+	}
+	if machine == nil {
+		return notAMachineReply(event, apiClient)
 	}
 
 	machineDir, err := getMachineDir(machine)


### PR DESCRIPTION
The rancher client now returns nils if it gets a 404 on a ById request.
It used to return an ApiError. Handle this difference.

Addresses #2925
