### PR TITLE
with DM 0.7.0, these azure fields will not be used anymore

### DIFF
--- a/handlers/providers/azure.go
+++ b/handlers/providers/azure.go
@@ -31,7 +31,7 @@ func (*AzureHandler) HandleCreate(machine *client.Machine, machineDir string) er
 		return errors.New(machine.Driver + "Config does not exist on Machine " + machine.Id)
 	}
 	machineConfig := driverConfig.(map[string]interface{})
-	if machineConfig["subscriptionCert"].(string) != "" {
+	if _, ok := machineConfig["subscriptionCert"]; ok {
 		value := machineConfig["subscriptionCert"].(string)
 		filename = "subscription-cert.pem"
 		path, err := saveDataToFile(filename, value, machineDir)
@@ -39,7 +39,7 @@ func (*AzureHandler) HandleCreate(machine *client.Machine, machineDir string) er
 			return err
 		}
 		machineConfig["subscriptionCert"] = path
-	} else {
+	} else if _, ok := machineConfig["publishSettingsFile"]; ok {
 		value := machineConfig["publishSettingsFile"].(string)
 		filename = "publish-settings.xml"
 		path, err := saveDataToFile(filename, value, machineDir)

--- a/handlers/providers/azure_test.go
+++ b/handlers/providers/azure_test.go
@@ -54,3 +54,25 @@ func TestAzureHandler(t *testing.T) {
 	}
 
 }
+
+func TestAzureHandler_DM_0_7(t *testing.T) {
+	machine := new(client.Machine)
+	machineDir := "."
+
+	machine.Driver = "azure"
+	data := make(map[string]interface{})
+	machine.Data = data
+	fields := make(map[string]interface{})
+	data["fields"] = fields
+	azureConfig := make(map[string]interface{})
+	fields["azureConfig"] = azureConfig
+
+	azureHandler := &AzureHandler{}
+
+	err := azureHandler.HandleCreate(machine, machineDir)
+
+	if err != nil {
+		t.Errorf("not Docker Machine 0.7.0 ready, err=%v", err)
+		return
+	}
+}


### PR DESCRIPTION
@cjellick - This is needed because from dm 0.7.0, these fields will not be populated, and we don't want GMS to panic everytime someone tries to create a Azure host.

With this fix, GMS will work woth dm 0.7 without losing support for the previous versions 
