### PR TITLE
Fix make build

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -4,7 +4,7 @@ RUN go get github.com/golang/lint/golint
 RUN curl -sL https://get.docker.com/builds/Linux/x86_64/docker-1.9.1 > /usr/bin/docker && \
     chmod +x /usr/bin/docker
 RUN apt-get update && \
-    apt-get install -y xz-utils
+    apt-get install -y --force-yes xz-utils
 ENV PATH /go/bin:$PATH
 ENV DAPPER_SOURCE /go/src/github.com/rancher/go-machine-service
 ENV DAPPER_OUTPUT bin dist


### PR DESCRIPTION
When `make build` was issued this is what i got:
```
The following NEW packages will be installed:
  xz-utils
  0 upgraded, 1 newly installed, 0 to remove and 40 not upgraded.
  Need to get 221 kB of archives.
  After this operation, 483 kB of additional disk space will be used.
  WARNING: The following packages cannot be authenticated!
    xz-utils
    E: There are problems and -y was used without --force-yes
    The command '/bin/sh -c apt-get update &&     apt-get install -y xz-utils' returned a non-zero code: 100
    FATA[0060] exit status 100
    make: *** [build] Error 1
```