### PR TITLE
Log the service (gms) in every log message

### DIFF
--- a/dynamic/builtin.go
+++ b/dynamic/builtin.go
@@ -1,7 +1,6 @@
 package dynamic
 
 import (
-	"github.com/Sirupsen/logrus"
 	"github.com/docker/machine/libmachine/drivers/plugin/localbinary"
 	"github.com/rancher/go-rancher/v2"
 )
@@ -36,14 +35,14 @@ func SyncBuiltin() error {
 			installed[driver.Name] = driver
 		}
 		if driver.State == "inactive" && driver.DefaultActive {
-			logrus.Infof("Activating driver %s", driver.Name)
+			logger.Infof("Activating driver %s", driver.Name)
 			apiClient.MachineDriver.ActionActivate(&driver)
 		}
 	}
 
 	for _, driver := range localbinary.CoreDrivers {
 		if _, ok := installed[driver]; !ok && !ignoredDrivers[driver] {
-			logrus.Infof("Installing builtin driver %s", driver)
+			logger.Infof("Installing builtin driver %s", driver)
 			apiClient.MachineDriver.Create(&client.MachineDriver{
 				Name:    driver,
 				Builtin: true,
@@ -54,7 +53,7 @@ func SyncBuiltin() error {
 	}
 
 	for _, driver := range installed {
-		logrus.Infof("Deleting old builtin driver %s", driver)
+		logger.Infof("Deleting old builtin driver %s", driver)
 		apiClient.MachineDriver.Delete(&driver)
 	}
 

--- a/dynamic/driver.go
+++ b/dynamic/driver.go
@@ -20,8 +20,10 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/rancher/go-machine-service/logging"
 )
+
+var logger = logging.Logger()
 
 type Driver struct {
 	builtin bool
@@ -100,7 +102,7 @@ func (d *Driver) getError() error {
 	errFile := d.cacheFile() + ".error"
 
 	if content, err := ioutil.ReadFile(errFile); err == nil {
-		logrus.Errorf("Returning previous error: %s", content)
+		logger.Errorf("Returning previous error: %s", content)
 		d.ClearError()
 		return errors.New(string(content))
 	}
@@ -181,7 +183,7 @@ func (d *Driver) Install() error {
 	}
 	defer src.Close()
 
-	logrus.Infof("Copying %s => %s", d.srcBinName(), path.Join(binDir(), d.name))
+	logger.Infof("Copying %s => %s", d.srcBinName(), path.Join(binDir(), d.name))
 	_, err = io.Copy(f, src)
 	return err
 }
@@ -268,7 +270,7 @@ func (d *Driver) copyBinary(cacheFile, input string) (string, error) {
 		return "", err
 	}
 
-	logrus.Infof("Found driver %s", driverName)
+	logger.Infof("Found driver %s", driverName)
 	return driverName, ioutil.WriteFile(cacheFile, []byte(driverName), 0644)
 }
 
@@ -313,7 +315,7 @@ func getHasher(hash string) (hash.Hash, error) {
 }
 
 func (d *Driver) download(dest io.Writer) error {
-	logrus.Infof("Download %s", d.url)
+	logger.Infof("Download %s", d.url)
 	resp, err := http.Get(d.url)
 	if err != nil {
 		return err

--- a/dynamic/driver_info.go
+++ b/dynamic/driver_info.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 	"sync"
 
-	log "github.com/Sirupsen/logrus"
 	cli "github.com/docker/machine/libmachine/mcnflag"
 
 	"net/rpc"
@@ -122,7 +121,7 @@ func RemoveSchemas(schemaName string, apiClient *client.RancherClient) error {
 			continue
 		}
 
-		log.Debugf("Removing %s id: %s state: %s", schemaName, schema.Id, schema.State)
+		logger.Debugf("Removing %s id: %s state: %s", schemaName, schema.Id, schema.State)
 		if err := apiClient.DynamicSchema.Delete(&schema); err != nil {
 			return err
 		}
@@ -150,7 +149,7 @@ func uploadDynamicSchema(schemaName, definition, parent string, roles []string, 
 		Parent:     parent,
 		Roles:      roles,
 	})
-	log.WithField("id", schema.Id).Infof("Creating schema %s, roles %v", schemaName, roles)
+	logger.WithField("id", schema.Id).Infof("Creating schema %s, roles %v", schemaName, roles)
 	if err != nil {
 		return fmt.Errorf("Failed when uploading %s schema: %v", schemaName, err)
 	}
@@ -159,7 +158,7 @@ func uploadDynamicSchema(schemaName, definition, parent string, roles []string, 
 }
 
 func getCreateFlagsForDriver(driver string) ([]cli.Flag, error) {
-	log.Debug("Starting binary ", driver)
+	logger.Debug("Starting binary ", driver)
 	p, err := localbinary.NewPlugin(driver)
 	if err != nil {
 		return nil, err
@@ -167,7 +166,7 @@ func getCreateFlagsForDriver(driver string) ([]cli.Flag, error) {
 	go func() {
 		err := p.Serve()
 		if err != nil {
-			log.Debugf("Error serving plugin server for driver=%s, err=%v", driver, err)
+			logger.Debugf("Error serving plugin server for driver=%s, err=%v", driver, err)
 		}
 	}()
 	defer p.Close()

--- a/dynamic/machine.go
+++ b/dynamic/machine.go
@@ -3,7 +3,6 @@ package dynamic
 import (
 	"strings"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/rancher/go-rancher/v2"
 )
 
@@ -26,7 +25,7 @@ func UploadMachineSchemas(apiClient *client.RancherClient, drivers ...string) er
 		}
 	}
 
-	log.Infof("Updating machine jsons for  %v", drivers)
+	logger.Infof("Updating machine jsons for  %v", drivers)
 	if err := uploadMachineServiceJSON(drivers, true); err != nil {
 		return err
 	}

--- a/dynamic/start.go
+++ b/dynamic/start.go
@@ -1,7 +1,6 @@
 package dynamic
 
 import (
-	"github.com/Sirupsen/logrus"
 	"github.com/rancher/go-rancher/v2"
 )
 
@@ -38,7 +37,7 @@ func ReactivateOldDrivers() error {
 
 	for _, driver := range drivers.Data {
 		if driver.SchemaVersion != version {
-			logrus.Infof("Updating driver %s from %s => %s", driver.Name, driver.SchemaVersion, version)
+			logger.Infof("Updating driver %s from %s => %s", driver.Name, driver.SchemaVersion, version)
 			_, err := apiClient.MachineDriver.ActionReactivate(&driver)
 			if err != nil {
 				return err
@@ -50,12 +49,12 @@ func ReactivateOldDrivers() error {
 }
 
 func DownloadAllDrivers() error {
-	logrus.Info("Installing builtin drivers")
+	logger.Info("Installing builtin drivers")
 	if err := SyncBuiltin(); err != nil {
 		return err
 	}
 
-	logrus.Info("Downloading all drivers")
+	logger.Info("Downloading all drivers")
 	apiClient, err := getClient()
 	if err != nil {
 		return err
@@ -77,13 +76,13 @@ func DownloadAllDrivers() error {
 		}
 
 		if err != nil {
-			logrus.Errorf("Failed to download/install driver %s: %v", driverInfo.Name, err)
+			logger.Errorf("Failed to download/install driver %s: %v", driverInfo.Name, err)
 			if _, err := apiClient.MachineDriver.ActionReactivate(&driverInfo); err != nil {
 				return err
 			}
 		}
 	}
 
-	logrus.Info("Done downloading all drivers")
+	logger.Info("Done downloading all drivers")
 	return nil
 }

--- a/handlers/bootstrap.go
+++ b/handlers/bootstrap.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	"github.com/Sirupsen/logrus"
 	"github.com/docker/distribution/reference"
 	docker "github.com/fsouza/go-dockerclient"
 	"github.com/rancher/event-subscriber/events"
@@ -28,7 +28,7 @@ const (
 var endpointRegEx = regexp.MustCompile("-H=[[:alnum:]]*[[:graph:]]*")
 
 func ActivateMachine(event *events.Event, apiClient *client.RancherClient) (err error) {
-	log.WithFields(log.Fields{
+	logger.WithFields(logrus.Fields{
 		"resourceId": event.ResourceID,
 		"eventId":    event.ID,
 	}).Info("Activating Machine")
@@ -75,7 +75,7 @@ func ActivateMachine(event *events.Event, apiClient *client.RancherClient) (err 
 	if err != nil {
 		return err
 	}
-	log.WithFields(log.Fields{
+	logger.WithFields(logrus.Fields{
 		"resourceId":  event.ResourceID,
 		"machineId":   machine.Id,
 		"containerId": container.ID,
@@ -104,7 +104,7 @@ func ActivateMachine(event *events.Event, apiClient *client.RancherClient) (err 
 	}
 
 	if !found {
-		log.WithFields(log.Fields{
+		logger.WithFields(logrus.Fields{
 			"resourceId": event.ResourceID,
 			"machineId":  machine.Id,
 		}).Error("Failed to find rancher-agent container")
@@ -121,7 +121,7 @@ func ActivateMachine(event *events.Event, apiClient *client.RancherClient) (err 
 			if err != nil {
 				continue
 			}
-			log.WithFields(log.Fields{
+			logger.WithFields(logrus.Fields{
 				"resourceId":        event.ResourceID,
 				"machineExternalId": machine.ExternalId,
 				"repo":              repo,
@@ -131,7 +131,7 @@ func ActivateMachine(event *events.Event, apiClient *client.RancherClient) (err 
 		}
 	}()
 
-	log.WithFields(log.Fields{
+	logger.WithFields(logrus.Fields{
 		"resourceId":        event.ResourceID,
 		"machineExternalId": machine.ExternalId,
 		"containerId":       container.ID,
@@ -220,7 +220,7 @@ func pullImage(dockerClient *docker.Client, imageRepo, imageTag string) error {
 		Tag:        imageTag,
 	}
 	imageAuth := docker.AuthConfiguration{}
-	log.Printf("pulling %v:%v image.", imageRepo, imageTag)
+	logger.Printf("pulling %v:%v image.", imageRepo, imageTag)
 	err := dockerClient.PullImage(imageOptions, imageAuth)
 	if err != nil {
 		return err
@@ -239,12 +239,12 @@ var getRegistrationURLAndImage = func(accountID string, apiClient *client.Ranche
 
 	var token client.RegistrationToken
 	if len(tokenCollection.Data) >= 1 {
-		log.WithFields(log.Fields{
+		logger.WithFields(logrus.Fields{
 			"accountId": accountID,
 		}).Debug("Found token for account")
 		token = tokenCollection.Data[0]
 	} else {
-		log.WithFields(log.Fields{
+		logger.WithFields(logrus.Fields{
 			"accountId": accountID,
 		}).Debug("Creating new token for account")
 		createToken := &client.RegistrationToken{

--- a/handlers/check_provider.go
+++ b/handlers/check_provider.go
@@ -9,7 +9,7 @@ import (
 func CheckProvider(event *events.Event, apiClient *client.RancherClient) error {
 	err := checkProvider(event, apiClient)
 	if err != nil {
-		logrus.WithFields(logrus.Fields{
+		logger.WithFields(logrus.Fields{
 			"eventId":    event.ID,
 			"resourceId": event.ResourceID,
 		}).Errorf("Failed to check provider: %v", err)
@@ -41,7 +41,7 @@ func checkProvider(event *events.Event, apiClient *client.RancherClient) error {
 	}
 
 	if state == "Error" {
-		logrus.WithFields(logrus.Fields{
+		logger.WithFields(logrus.Fields{
 			"hostId": host.Id,
 		}).Info("Deleting host")
 		_, err := apiClient.ExternalHostEvent.Create(&client.ExternalHostEvent{

--- a/handlers/common.go
+++ b/handlers/common.go
@@ -6,9 +6,9 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/Sirupsen/logrus"
 	"github.com/pkg/errors"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/rancher/event-subscriber/events"
 	client "github.com/rancher/go-rancher/v2"
 )
@@ -204,7 +204,7 @@ func newReply(event *events.Event) *client.Publish {
 }
 
 func cleanupResources(machineDir, name string) error {
-	log.WithFields(log.Fields{
+	logger.WithFields(logrus.Fields{
 		"machine name": name,
 	}).Info("starting cleanup...")
 	dExists, err := dirExists(machineDir)
@@ -235,7 +235,7 @@ func cleanupResources(machineDir, name string) error {
 
 	removeMachineDir(machineDir)
 
-	log.WithFields(log.Fields{
+	logger.WithFields(logrus.Fields{
 		"machine name": name,
 	}).Info("cleanup successful")
 	return nil

--- a/handlers/config.go
+++ b/handlers/config.go
@@ -12,9 +12,12 @@ import (
 	"path/filepath"
 	"strings"
 
-	log "github.com/Sirupsen/logrus"
+	"github.com/Sirupsen/logrus"
+	"github.com/rancher/go-machine-service/logging"
 	client "github.com/rancher/go-rancher/v2"
 )
+
+var logger = logging.Logger()
 
 func restoreMachineDir(machine *client.Machine, baseDir string) error {
 	machineBaseDir := filepath.Dir(baseDir)
@@ -48,7 +51,7 @@ func restoreMachineDir(machine *client.Machine, baseDir string) error {
 
 		filename := header.Name
 		filePath := filepath.Join(machineBaseDir, filename)
-		log.Infof("Extracting %v", filePath)
+		logger.Infof("Extracting %v", filePath)
 
 		info := header.FileInfo()
 		if info.IsDir() {
@@ -72,7 +75,7 @@ func restoreMachineDir(machine *client.Machine, baseDir string) error {
 }
 
 func createExtractedConfig(baseDir string, machine *client.Machine) (string, error) {
-	log.WithFields(log.Fields{
+	logger.WithFields(logrus.Fields{
 		"resourceId": machine.Id,
 	}).Info("Creating and uploading extracted machine config")
 

--- a/handlers/create.go
+++ b/handlers/create.go
@@ -27,7 +27,7 @@ const (
 var regExHyphen = regexp.MustCompile("([a-z])([A-Z])")
 
 func CreateMachine(event *events.Event, apiClient *client.RancherClient) error {
-	log := logrus.WithFields(logrus.Fields{
+	log := logger.WithFields(logrus.Fields{
 		"resourceId": event.ResourceID,
 		"eventId":    event.ID,
 	})
@@ -111,12 +111,12 @@ func CreateMachine(event *events.Event, apiClient *client.RancherClient) error {
 }
 
 func logProgress(readerStdout io.Reader, readerStderr io.Reader, publishChan chan<- string, machine *client.Machine, event *events.Event, errChan chan<- string, providerHandler providers.Provider) {
-	// We will just log stdout first, then stderr, ignoring all errors.
+	// We will just logging stdout first, then stderr, ignoring all errors.
 	defer close(errChan)
 	scanner := bufio.NewScanner(readerStdout)
 	for scanner.Scan() {
 		msg := scanner.Text()
-		logrus.WithFields(logrus.Fields{
+		logger.WithFields(logrus.Fields{
 			"resourceId: ": event.ResourceID,
 		}).Infof("stdout: %s", msg)
 		transitionMsg := filterDockerMessage(msg, machine, errChan, providerHandler, false)
@@ -127,7 +127,7 @@ func logProgress(readerStdout io.Reader, readerStderr io.Reader, publishChan cha
 	scanner = bufio.NewScanner(readerStderr)
 	for scanner.Scan() {
 		msg := scanner.Text()
-		logrus.WithFields(logrus.Fields{
+		logger.WithFields(logrus.Fields{
 			"resourceId": event.ResourceID,
 		}).Infof("stderr: %s", msg)
 		filterDockerMessage(msg, machine, errChan, providerHandler, true)
@@ -236,7 +236,7 @@ func buildMachineCreateCmd(machine *client.Machine) ([]string, error) {
 	}
 
 	cmd = append(cmd, machine.Name)
-	logrus.Infof("Cmd slice: %v", cmd)
+	logger.Infof("Cmd slice: %v", cmd)
 	return cmd, nil
 }
 

--- a/handlers/machine_driver.go
+++ b/handlers/machine_driver.go
@@ -18,7 +18,7 @@ func RemoveDriver(event *events.Event, apiClient *client.RancherClient) error {
 }
 
 func removeDriver(event *events.Event, apiClient *client.RancherClient, delete bool) error {
-	logrus.WithFields(logrus.Fields{
+	logger.WithFields(logrus.Fields{
 		"resourceId": event.ResourceID,
 		"eventId":    event.ID,
 		"name":       event.Name,
@@ -36,7 +36,7 @@ func removeDriver(event *events.Event, apiClient *client.RancherClient, delete b
 	if driverInfo.Checksum == "" || delete {
 		driver, err := getDriver(event.ResourceID, apiClient)
 		if err == nil {
-			logrus.Infof("Removing driver %s", driverInfo.Name)
+			logger.Infof("Removing driver %s", driverInfo.Name)
 			driver.Remove()
 		}
 	}
@@ -50,7 +50,7 @@ func removeDriver(event *events.Event, apiClient *client.RancherClient, delete b
 }
 
 func ErrorDriver(event *events.Event, apiClient *client.RancherClient) error {
-	logrus.WithFields(logrus.Fields{
+	logger.WithFields(logrus.Fields{
 		"resourceId": event.ResourceID,
 		"eventId":    event.ID,
 		"name":       event.Name,
@@ -69,7 +69,7 @@ func ErrorDriver(event *events.Event, apiClient *client.RancherClient) error {
 }
 
 func ActivateDriver(event *events.Event, apiClient *client.RancherClient) error {
-	logrus.WithFields(logrus.Fields{
+	logger.WithFields(logrus.Fields{
 		"resourceId": event.ResourceID,
 		"eventId":    event.ID,
 		"name":       event.Name,
@@ -131,6 +131,7 @@ func activate(id string, apiClient *client.RancherClient) (*dynamic.Driver, erro
 	}
 
 	if err := driver.Install(); err != nil {
+		logger.Errorf("Failed to download/install driver %s: %v", driver.Name(), err)
 		return nil, err
 	}
 

--- a/handlers/providers/amazonec2.go
+++ b/handlers/providers/amazonec2.go
@@ -3,14 +3,13 @@ package providers
 import (
 	"strings"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/rancher/go-rancher/v2"
 )
 
 func init() {
 	amazonec2Handler := &AmazonEC2Handler{}
 	if err := RegisterProvider("amazonec2", amazonec2Handler); err != nil {
-		log.Fatal("could not register amazonec2 provider")
+		logger.Fatal("could not register amazonec2 provider")
 	}
 }
 

--- a/handlers/providers/azure.go
+++ b/handlers/providers/azure.go
@@ -6,14 +6,17 @@ import (
 	"path/filepath"
 
 	"errors"
-	log "github.com/Sirupsen/logrus"
+
+	"github.com/rancher/go-machine-service/logging"
 	"github.com/rancher/go-rancher/v2"
 )
+
+var logger = logging.Logger()
 
 func init() {
 	azureHandler := &AzureHandler{}
 	if err := RegisterProvider("azure", azureHandler); err != nil {
-		log.Fatal("could not register azure provider")
+		logger.Fatal("could not register azure provider")
 	}
 }
 

--- a/handlers/providers/digitalocean.go
+++ b/handlers/providers/digitalocean.go
@@ -3,14 +3,13 @@ package providers
 import (
 	"strings"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/rancher/go-rancher/v2"
 )
 
 func init() {
 	digitaloceanHandler := &DigitaloceanHandler{}
 	if err := RegisterProvider("digitalocean", digitaloceanHandler); err != nil {
-		log.Fatal("could not register digitalocean provider")
+		logger.Fatal("could not register digitalocean provider")
 	}
 }
 

--- a/handlers/providers/packet.go
+++ b/handlers/providers/packet.go
@@ -3,14 +3,13 @@ package providers
 import (
 	"strings"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/rancher/go-rancher/v2"
 )
 
 func init() {
 	packetHandler := &PacketHandler{}
 	if err := RegisterProvider("packet", packetHandler); err != nil {
-		log.Fatal("could not register packet provider")
+		logger.Fatal("could not register packet provider")
 	}
 }
 

--- a/handlers/providers/rackspace.go
+++ b/handlers/providers/rackspace.go
@@ -1,14 +1,13 @@
 package providers
 
 import (
-	log "github.com/Sirupsen/logrus"
 	"github.com/rancher/go-rancher/v2"
 )
 
 func init() {
 	rackspaceHandler := &RackspaceHandler{}
 	if err := RegisterProvider("rackspace", rackspaceHandler); err != nil {
-		log.Fatal("could not register rackspace provider")
+		logger.Fatal("could not register rackspace provider")
 	}
 }
 

--- a/handlers/remove.go
+++ b/handlers/remove.go
@@ -1,13 +1,13 @@
 package handlers
 
 import (
-	log "github.com/Sirupsen/logrus"
+	"github.com/Sirupsen/logrus"
 	"github.com/rancher/event-subscriber/events"
 	client "github.com/rancher/go-rancher/v2"
 )
 
 func PurgeMachine(event *events.Event, apiClient *client.RancherClient) error {
-	log.WithFields(log.Fields{
+	logger.WithFields(logrus.Fields{
 		"resourceId": event.ResourceID,
 		"eventId":    event.ID,
 	}).Info("Purging Machine")
@@ -29,7 +29,7 @@ func PurgeMachine(event *events.Event, apiClient *client.RancherClient) error {
 		}
 	}
 
-	log.WithFields(log.Fields{
+	logger.WithFields(logrus.Fields{
 		"resourceId":        event.ResourceID,
 		"machineExternalId": machine.ExternalId,
 		"machineDir":        machineDir,

--- a/logging/log.go
+++ b/logging/log.go
@@ -1,0 +1,11 @@
+package logging
+
+import "github.com/Sirupsen/logrus"
+
+var log = logrus.WithFields(logrus.Fields{
+	"service": "gms",
+})
+
+func Logger() *logrus.Entry {
+	return log
+}


### PR DESCRIPTION
Create a common logger that has the field service=gms set so that every
time we log, we get the service. This is important because gms logs are
in the rancher/server container and intermingled with other go services.

Logs will look like this:
```
time="2017-04-27T11:21:05-07:00" level=info msg="Creating Machine" eventId=2e2f09dd-d271-485a-bac5-222a727ff2a6 resourceId=1ph1 service=gms 
time="2017-04-27T11:21:05-07:00" level=info msg="Activating Machine" eventId=1ee5241e-19c5-4d4a-8ba2-c0ead74b4042 resourceId=1ph1 service=gms 
```
Unforturnately, I can't control where the service is put. I'd prefer it be after the level, but that's not configurable as far as I could tell.